### PR TITLE
Add the embedding map layout stage

### DIFF
--- a/Postprocessor/ClusterNaming/apply_cluster_names.sql
+++ b/Postprocessor/ClusterNaming/apply_cluster_names.sql
@@ -1,0 +1,25 @@
+-- Loads the curated cluster display names (cluster_display_names.csv — the
+-- name_clusters_muq.py proposals after human review) into the backend-owned
+-- track_map_cluster table. Run from the directory holding the CSV:
+--   psql "$CONN" -f apply_cluster_names.sql
+--
+-- Names are only meaningful for the layout run they were listened against:
+-- k-means labels are relabeled by size each generate_track_map.py run, so a
+-- re-layout MUST be followed by re-naming (or by truncating this table until
+-- names exist again). Wipe-and-reload, same discipline as track_map itself.
+
+BEGIN;
+
+CREATE TEMP TABLE tmp_cluster_names (
+    cluster smallint,
+    name    text
+) ON COMMIT DROP;
+
+\copy tmp_cluster_names FROM 'cluster_display_names.csv' WITH CSV
+
+TRUNCATE track_map_cluster;
+
+INSERT INTO track_map_cluster (cluster, name)
+SELECT cluster, name FROM tmp_cluster_names;
+
+COMMIT;

--- a/Postprocessor/ClusterNaming/cluster_display_names.csv
+++ b/Postprocessor/ClusterNaming/cluster_display_names.csv
@@ -1,0 +1,48 @@
+0,DJ megamixes & crossfade demos
+1,Bright rock/synth arranges
+2,Vocal pop & denpa
+3,Nonstop hardcore mixes
+4,J-rock/pop vocals
+5,Makina & hardcore rave
+6,Kawaii future bass
+7,Vocal EDM
+8,Instrumental trance
+9,Happy hardcore megamixes
+10,Uplifting trance & eurobeat
+11,Melodic house
+12,Game-synth medleys
+13,Instrumental metal/rock
+14,R&B-tinged pop
+15,Vocal rock/pop
+16,Techno & trance
+17,Mixed band/orchestral
+18,Fast game-synth arranges
+19,Bright vocal rock
+20,Dark vocal rock
+21,Heavy instrumental metal
+22,Grand orchestral
+23,Hard dance
+24,Disco & band funk
+25,Soft ballads & folk
+26,Martial orchestral
+27,Chamber strings & ballads
+28,Extreme metal
+29,Solo piano (emotive)
+30,Jazz & bossa
+31,Funk/house groove
+32,Violin classical & waltz
+33,Future bass & dubstep
+34,Solo piano (classical)
+35,Live recordings
+36,Ska & symphonic rock
+37,Hard techno & breakcore
+38,Lo-fi oddities
+39,Music box & gentle acoustic
+40,Latin/world groove
+41,Tango & waltz ballads
+42,Voice dramas & rap
+43,Music box miniatures
+44,Chiptune & PC-98 retro
+45,Electronic groove/IDM
+46,Voice dramas with SE
+47,Quiet oddments

--- a/Postprocessor/ClusterNaming/cluster_names.2026-07-30.csv
+++ b/Postprocessor/ClusterNaming/cluster_names.2026-07-30.csv
@@ -1,0 +1,49 @@
+cluster,n_scored,top_by_lift,top_raw,medoid_titles
+0,16,vocal trance (+0.91); choir (+0.84); cinematic epic (+0.83); dubstep (+0.80); trance (+0.79),happy hardcore; vocal trance; denpa,Special Megamix / SPECIAL MEGAMIX / For you クロスフェードデモ
+1,16,retro game synth (+1.03); symphonic metal (+0.75); disco (+0.69); harpsichord baroque (+0.61); vocal rock (+0.56),vocal rock; happy hardcore; vocal pop,Immoral Sister ～紅に染まる片翼 / 凋叶棕 - Q / 焔の海
+2,16,vocal pop (+0.79); happy hardcore (+0.74); vocal trance (+0.65); electro swing (+0.63); denpa (+0.60),happy hardcore; vocal pop; denpa,∀ＫＢ抜総選挙 ～目指せセンター！～ / 蔷薇偶像(Live at ©Gensokyo武道馆) / 音轨序号05
+3,16,eurodance (+1.13); breakcore (+1.07); happy hardcore (+1.06); eurobeat (+1.02); electro swing (+1.00),happy hardcore; vocal trance; denpa,"TOHO Gomennasai MIX - hu-zin / Live @ Sampling Business 2 (Nov 30, 2024) / Bonus Track"
+4,16,vocal rock (+1.59); vocal pop (+1.22); denpa (+0.96); happy hardcore (+0.95); ska (+0.88),vocal rock; vocal pop; happy hardcore,純真Velvet / 森羅万象スターターメドレー2022 / 花
+5,16,trance (+1.27); eurobeat (+1.24); drum and bass (+1.22); techno (+1.10); breakcore (+1.10),happy hardcore; trance; vocal trance,Special DJ Mix Disc / TOHO Gomennasai MIX - pocotan / Makina VS Hardcore VS Toho Project
+6,16,kawaii edm (+1.46); future bass (+1.36); vocal trance (+1.19); eurodance (+1.04); dubstep (+0.92),vocal pop; vocal trance; happy hardcore,ボカロEDM10 HEAVY & SWEET DEMO / ボカロEDM10 HEAVY & SWEET DEMO / ボカロEDM6 13Track
+7,16,vocal trance (+1.23); happy hardcore (+1.04); a cappella (+1.04); vocal pop (+1.03); kawaii edm (+0.98),happy hardcore; vocal pop; denpa,EDM5 15Track / 東方ベストEDM2 15Track / こなぐすり 幽閉樂祭 2012 スペシャルメドレー
+8,16,trance (+1.42); eurodance (+1.29); house (+1.02); techno (+1.01); ambient (+0.95),trance; vocal trance; happy hardcore,TOHO INST EDM7 11Track / ☆Sped Star DeluXe☆ -The MEDLEY OF KIRBY SSDX2- / 想起 -Girl Revolution-
+9,16,happy hardcore (+1.41); vocal trance (+1.39); eurodance (+1.26); a cappella (+1.24); choir (+1.24),happy hardcore; denpa; vocal trance,Non-Stop Mega Mix By DJ Katsu / Special Megamix By DJ もっちー / Special Non-Stop Mix by DJ S'RON
+10,16,trance (+1.36); eurobeat (+1.17); techno (+1.03); eurodance (+1.01); hardstyle (+0.94),happy hardcore; trance; eurobeat,"Sensation In The Sky 30min Nonstop Mix / Last Dance / SBFR-0103 ""TRUE COLORS 3"" Cross Fade Sample"
+11,16,house (+1.16); eurodance (+1.01); trance (+0.92); ambient (+0.89); disco (+0.81),trance; happy hardcore; vocal trance,Super Rabbit / Attack Like a Flying Bird / タイムパラドックス
+12,16,retro game synth (+0.95); trance (+0.71); eurodance (+0.71); disco (+0.66); eurobeat (+0.61),happy hardcore; vocal pop; vocal rock,Touhou Extra Bosses Fusion Collab / 時よ無常なる彼方へ / Scarlet Breaks Medley
+13,16,metal (+1.47); symphonic metal (+1.44); instrumental rock (+1.42); vocal rock (+1.14); post-rock (+0.96),vocal rock; symphonic metal; happy hardcore,ハピスクお試しcrossfade demo / Resolution / Another rain
+14,16,r&b (+0.92); electro swing (+0.91); vocal pop (+0.87); kawaii edm (+0.79); hip-hop (+0.78),vocal pop; denpa; happy hardcore,TAM3-0108 東方弦奏歌-VARIABLE- CROSSFADE REMIX / TAM3-0119 東方弦奏歌-OCTAVE- CROSSFADE REMIX / あたいの最強のライブ
+15,16,wagakki (+0.50); vocal pop (+0.45); r&b (+0.40); celtic folk (+0.37); vocal rock (+0.37),vocal pop; vocal rock; happy hardcore,Invitations to... / 少女期の終わりに / A-9's reincarnation
+16,16,techno (+1.19); trance (+1.19); eurodance (+1.18); house (+0.97); hardstyle (+0.94),trance; happy hardcore; vocal trance,東方インストEDM10 [DISC1]クロスフェードデモ / Rolling Contact Promotion Mix 2017 / 東方インストEDM2 クロスフェードデモ
+17,16,post-rock (+0.57); orchestral (+0.55); brass march (+0.49); funk (+0.48); symphonic metal (+0.43),vocal rock; symphonic metal; disco,明日カレーの日、ゲゲゲの鬼次郎 / 始原のビート 〜 Pristine Beat -オーケストラ- / Carezza
+18,16,eurobeat (+0.78); drum and bass (+0.75); speedcore (+0.68); chiptune (+0.68); retro game synth (+0.67),happy hardcore; vocal rock; denpa,Restrict Extra Play / 七星の剣 / AREA CODE(CYBERIA MIX)
+19,16,vocal rock (+1.64); instrumental rock (+1.29); metal (+1.28); symphonic metal (+1.27); ska (+1.01),vocal rock; happy hardcore; vocal pop,Rainbow Sky! / Rainbow Sky / SEE YOU AGAIN!
+20,16,vocal rock (+1.56); vocal pop (+1.04); denpa (+0.89); instrumental rock (+0.78); happy hardcore (+0.77),vocal rock; vocal pop; happy hardcore,亡きふたりのための / 月虹リミテッド・アワー / 累々たる死の肖像
+21,16,metal (+1.48); instrumental rock (+1.29); symphonic metal (+1.27); post-rock (+0.94); vocal rock (+0.87),vocal rock; symphonic metal; happy hardcore,Venus <Another Phaze Mix> / Venus <Another Phaze Mix> / 記憶の欠片
+22,16,orchestral (+1.82); violin classical (+1.14); brass march (+1.02); waltz (+0.95); pipe organ (+0.82),symphonic metal; violin classical; pipe organ,三千大世界の聖火／原曲：感情の摩天楼　～ Cosmic Mind / Memories of Scarlet ～紅の記憶 / 四季映像 ～Legend of Xanadu
+23,16,drum and bass (+1.21); techno (+1.16); hardstyle (+1.15); breakcore (+1.15); eurobeat (+1.10),happy hardcore; trance; eurobeat,AGGRESSIVE MEGA-MIX #05 / TechDance arrange promotion tracks / AGGRESSIVE MEGA-MIX #06
+24,16,disco (+0.76); funk (+0.64); big band (+0.64); symphonic metal (+0.58); post-rock (+0.58),vocal rock; vocal pop; disco,クロスフェード1 / 妖魔夜行 / 月時計 ～ ルナ・ダイアル
+25,16,vocal ballad (+0.78); r&b (+0.78); celtic folk (+0.72); retro game synth (+0.70); denpa (+0.67),denpa; vocal pop; vocal rock,あの日の夢のアリス ～DAY DREAM / 月の姫、永遠の姫 -世界と１人のひねくれ者- / Pikinini Kumul
+26,16,orchestral (+1.70); brass march (+1.38); big band (+0.93); cinematic epic (+0.87); violin classical (+0.83),symphonic metal; retro game synth; violin classical,上海アリス幻楽団サンプル / Dismantled Pandora's Box / 妖々夢
+27,16,orchestral (+1.22); violin classical (+1.13); waltz (+0.75); vocal ballad (+0.67); music box (+0.58),vocal ballad; violin classical; vocal rock,山犬の夢 / 胡桃·恶魔红响曲 / 聖樹
+28,16,metal (+2.35); symphonic metal (+1.92); instrumental rock (+1.75); speedcore (+1.38); hardstyle (+1.24),symphonic metal; vocal rock; speedcore,やまんばの６連アタック / デザイアドライブ / Cognitohazard Mixomatosis
+29,16,piano solo (+3.35); jazz (+1.18); acoustic (+1.14); synthwave (+1.08); tango (+0.84),piano solo; pipe organ; jazz,少女幻奏 / ラストリモート / 現し夜の帰りみち
+30,16,jazz (+1.28); bossa nova (+0.99); big band (+0.67); tango (+0.61); harpsichord baroque (+0.54),electro swing; jazz; vocal rock,Marionette -酔いに踊れ- / さとりのティーブレイク / As Time Goes By
+31,16,funk (+1.32); reggae (+0.86); electro swing (+0.83); jazz (+0.77); lo-fi (+0.68),electro swing; disco; happy hardcore,tohomania Forever 1st[tohomania NONSTOP MEGAMIX] / House Set of 東方天空璋 (2017 WIP) / Usimitsu3 rivers
+32,16,violin classical (+1.33); waltz (+1.28); tango (+0.92); orchestral (+0.69); music box (+0.64),denpa; waltz; happy hardcore,Lover's Scope　～⑥色ビーズと記憶の欠片 / 寂然の見世物 / つないだ右手と空の左手
+33,16,future bass (+1.33); kawaii edm (+1.20); dubstep (+0.96); breakcore (+0.77); vocal trance (+0.74),happy hardcore; vocal trance; vocal pop,Amadeus / ジェリーストーン / Decryption of The Lost Era
+34,16,piano solo (+3.35); jazz (+1.22); harpsichord baroque (+1.08); music box (+0.91); house (+0.91),piano solo; harpsichord baroque; pipe organ,Arcanelle-Holy Parade / ネイティブフェイス(難易度:Normal) / 東方萃夢想
+35,16,metal (+2.32); instrumental rock (+1.65); symphonic metal (+1.59); bossa nova (+1.42); post-rock (+1.27),symphonic metal; vocal rock; instrumental rock,奇子 ~Unknown Child (Live) / No Grudge Any More (Live) / DRAGON FORCE (Live)
+36,16,symphonic metal (+1.12); ska (+1.04); instrumental rock (+0.96); metal (+0.86); vocal rock (+0.76),vocal rock; happy hardcore; symphonic metal,Mementoof LIfe / Shadow Shooter / the chimera
+37,16,techno (+1.52); breakcore (+1.36); hardstyle (+1.19); drum and bass (+1.14); dubstep (+1.11),happy hardcore; breakcore; trance,soulgem (five mix) / BINARY FEELINGS (Separate Version) / s.c.a.r.l.e.t - instrumental -
+38,16,lo-fi (+1.03); noise experimental (+0.61); electro swing (+0.60); hip-hop (+0.56); r&b (+0.55),denpa; happy hardcore; a cappella,続・妖怪の山 ～天狗は写メった！～ / まぼろし / まぼろし
+39,16,music box (+1.21); wagakki (+1.03); celtic folk (+0.72); ambient (+0.69); waltz (+0.64),vocal ballad; music box; pipe organ,望郷 / 桜色コントレイル / オーラリーの残響
+40,16,tango (+1.12); funk (+1.11); reggae (+1.01); bossa nova (+0.91); jazz (+0.68),electro swing; disco; pipe organ,沈く追想 / Uoon Runaway! / Uoon Runaway!
+41,16,tango (+0.92); lo-fi (+0.79); orchestral (+0.79); waltz (+0.78); music box (+0.76),vocal ballad; pipe organ; waltz,夢のつづき (カラオケ) / The Other~Dreams-Ending 2 姬出 / Capella
+42,16,hip-hop (+2.08); r&b (+1.43); a cappella (+1.26); denpa (+1.14); vocal ballad (+0.94),denpa; a cappella; vocal pop,お使い狼と竹林の兎 / 霧の殺人鬼19 / 竹林のアマノジャク
+43,16,music box (+2.02); pipe organ (+1.36); celtic folk (+0.90); waltz (+0.69); lo-fi (+0.67),music box; pipe organ; denpa,人は誰も居ない / No.5 あ、あれ？　でも、退治して見せますわ！ / リコーダー交通組曲「歩道橋」
+44,16,chiptune (+3.14); retro game synth (+2.08); harpsichord baroque (+1.54); speedcore (+1.32); synthwave (+1.07),chiptune; retro game synth; speedcore,蛙遊びとミシャグジさま / Stage05 [遥か38万キロのボヤージュ] / 千年紅魔伝
+45,16,funk (+1.71); lo-fi (+1.38); reggae (+1.29); electro swing (+1.27); noise experimental (+1.05),electro swing; techno; breakcore,input / Machine's Melody / @home
+46,16,pipe organ (+1.79); noise experimental (+1.58); music box (+1.56); hip-hop (+1.19); kawaii edm (+0.97),a cappella; denpa; happy hardcore,霧の殺人鬼04 / ヤンデレの伊吹萃香に慕われて(BGM・SEありバージョン) / 手伝いのお礼(耳かき)
+47,16,pipe organ (+1.63); acoustic (+1.10); noise experimental (+0.93); piano solo (+0.90); music box (+0.69),a cappella; pipe organ; denpa,Untitled / Untitled / Untitled

--- a/Postprocessor/ClusterNaming/name_clusters_muq.py
+++ b/Postprocessor/ClusterNaming/name_clusters_muq.py
@@ -1,0 +1,195 @@
+"""Proposes names for the embedding-map clusters by listening to exemplars.
+
+Stage 1 of the genre plan: MERT space has no text alignment, so the 48 k-means
+acoustic families on the explore map are anonymous colors. This stage scores a
+sample of each cluster (10 medoids + 6 randoms from sample_cluster_tracks.sql)
+against a doujin-native vocabulary with MuQ-MuLan (OpenMuQ/MuQ-MuLan-large,
+CC-BY-NC 4.0 — fine here, not redistributable commercially), zero-shot.
+
+Clusters are named by LIFT, not raw score: per label z = (cluster mean - global
+mean) / global std across all sampled tracks. Raw scores would call every
+cluster "rock"; lift asks what a cluster has more of than the library does.
+
+Audio comes from the 128k HLS rung (self-contained fMP4), decoded with PyAV so
+no system ffmpeg is needed, resampled to MuQ's 24 kHz, center 30 s.
+
+Reads cluster_sample.csv from the cwd. Writes track_scores.csv (resumable:
+already-scored tracks are skipped on rerun) and cluster_names.csv, and prints
+the review report. Run:
+
+  uv run --no-project --with muq --with av --with soxr python name_clusters_muq.py
+"""
+
+import csv
+import os
+import sys
+import time
+
+import numpy as np
+
+LIBRARY_ROOT = "/mnt/tlmc/TLMC v6"
+HLS_RUNG = "hls/128k/stream.m4s"
+INPUT_CSV = "cluster_sample.csv"
+SCORES_CSV = "track_scores.csv"
+NAMES_CSV = "cluster_names.csv"
+
+TARGET_SR = 24000
+CLIP_SECONDS = 30
+
+# The vocabulary is the quality lever. Doujin-native styles, phrased the way a
+# music caption would read — MuLan-family models were trained on captions.
+VOCAB: list[tuple[str, str]] = [
+  ("eurobeat", "high energy eurobeat with driving synth riffs and fast beats"),
+  ("denpa", "hyperactive cute denpa song with high pitched female vocals"),
+  ("piano solo", "solo piano performance"),
+  ("orchestral", "epic orchestral arrangement with strings and brass"),
+  ("violin classical", "classical violin ensemble chamber piece"),
+  ("vocal ballad", "emotional slow ballad with female vocals"),
+  ("vocal pop", "upbeat japanese pop song with female vocals"),
+  ("vocal rock", "japanese rock song with female vocals and electric guitars"),
+  ("vocal trance", "uplifting vocal trance with female vocals and supersaw synths"),
+  ("trance", "melodic instrumental trance with supersaw synths"),
+  ("metal", "heavy metal with distorted guitars and double bass drums"),
+  ("symphonic metal", "symphonic metal with orchestra and heavy guitars"),
+  ("instrumental rock", "energetic instrumental rock with electric guitar melodies"),
+  ("post-rock", "atmospheric instrumental post rock build up"),
+  ("jazz", "jazz combo with swinging piano and walking bass"),
+  ("big band", "big band swing with brass section"),
+  ("bossa nova", "relaxed bossa nova with nylon guitar"),
+  ("celtic folk", "celtic folk with tin whistle fiddle and accordion"),
+  ("wagakki", "traditional japanese instruments koto shamisen and taiko drums"),
+  ("chiptune", "8-bit chiptune video game music"),
+  ("retro game synth", "retro synthesizer video game soundtrack with trumpet lead melody"),
+  ("house", "four on the floor house music with piano stabs"),
+  ("happy hardcore", "fast happy hardcore rave with pitched up vocals"),
+  ("speedcore", "extremely fast aggressive gabber speedcore with distorted kicks"),
+  ("drum and bass", "fast breakbeat drum and bass with rolling bassline"),
+  ("breakcore", "chaotic breakcore with chopped amen breaks"),
+  ("dubstep", "dubstep with heavy wobble bass drops"),
+  ("electro swing", "electro swing mixing jazz samples with dance beats"),
+  ("hip-hop", "hip hop beat with rap vocals"),
+  ("lo-fi", "lofi chill beats with dusty texture"),
+  ("ambient", "calm ambient soundscape with soft pads"),
+  ("acoustic", "acoustic guitar folk arrangement"),
+  ("a cappella", "unaccompanied vocal harmony group a cappella"),
+  ("funk", "funk groove with slap bass and horns"),
+  ("disco", "disco with four on the floor and strings"),
+  ("ska", "upbeat ska with horn section and offbeat guitar"),
+  ("techno", "driving techno with repetitive synth stabs"),
+  ("synthwave", "retro synthwave with analog synth arpeggios"),
+  ("future bass", "future bass with detuned synth chords and vocal chops"),
+  ("kawaii edm", "cute kawaii future bass with bright bells and vocal chops"),
+  ("hardstyle", "hardstyle with distorted kick and pitched leads"),
+  ("eurodance", "90s eurodance with catchy synth hook and dance beat"),
+  ("r&b", "smooth rnb with soulful vocals"),
+  ("reggae", "laid back reggae with offbeat skank guitar"),
+  ("brass march", "military march with brass band and snare drums"),
+  ("waltz", "elegant orchestral waltz in three four time"),
+  ("tango", "dramatic tango with accordion and strings"),
+  ("cinematic epic", "epic cinematic trailer music with choir and percussion"),
+  ("choir", "epic choir chanting with orchestra"),
+  ("music box", "delicate music box lullaby"),
+  ("harpsichord baroque", "baroque harpsichord piece"),
+  ("pipe organ", "church pipe organ piece"),
+  ("noise experimental", "harsh noise experimental sound collage"),
+]
+
+
+def decode_center_clip(path: str) -> np.ndarray | None:
+  import av
+  import soxr
+
+  try:
+    with av.open(path) as container:
+      stream = container.streams.audio[0]
+      rate = stream.rate or 44100
+      chunks = []
+      for frame in container.decode(stream):
+        chunks.append(frame.to_ndarray())
+  except Exception as error:  # noqa: BLE001 — one bad rip must not kill the run
+    print(f"  decode failed: {path}: {error}")
+    return None
+  if not chunks:
+    return None
+  audio = np.concatenate(chunks, axis=1).astype(np.float32)
+  mono = audio.mean(axis=0)
+  mono = soxr.resample(mono, rate, TARGET_SR)
+  want = TARGET_SR * CLIP_SECONDS
+  if len(mono) > want:
+    start = (len(mono) - want) // 2
+    mono = mono[start : start + want]
+  return mono
+
+
+def main():
+  import torch
+
+  torch.set_num_threads(os.cpu_count() or 8)
+
+  rows = list(csv.reader(open(INPUT_CSV)))
+  done: dict[str, list[float]] = {}
+  if os.path.exists(SCORES_CSV):
+    for row in csv.reader(open(SCORES_CSV)):
+      done[row[0]] = [float(v) for v in row[1:]]
+    print(f"resuming: {len(done)} tracks already scored")
+
+  from muq import MuQMuLan
+
+  print("loading MuQ-MuLan-large...")
+  mulan = MuQMuLan.from_pretrained("OpenMuQ/MuQ-MuLan-large").eval()
+
+  with torch.no_grad():
+    text_embeds = mulan(texts=[prompt for _, prompt in VOCAB])
+    text_embeds = torch.nn.functional.normalize(text_embeds, dim=-1)
+
+  t0 = time.time()
+  pending = [r for r in rows if r[1] not in done]
+  scores_file = open(SCORES_CSV, "a", newline="")
+  writer = csv.writer(scores_file)
+  for i, (cluster, track_id, role, title, media_key) in enumerate(pending):
+    clip = decode_center_clip(os.path.join(LIBRARY_ROOT, media_key, HLS_RUNG))
+    if clip is None:
+      continue
+    with torch.no_grad():
+      audio_embed = mulan(wavs=torch.from_numpy(clip).unsqueeze(0))
+      audio_embed = torch.nn.functional.normalize(audio_embed, dim=-1)
+      sims = (audio_embed @ text_embeds.T).squeeze(0).tolist()
+    done[track_id] = sims
+    writer.writerow([track_id] + [f"{v:.5f}" for v in sims])
+    scores_file.flush()
+    if (i + 1) % 20 == 0:
+      rate = (time.time() - t0) / (i + 1)
+      print(
+        f"  {i + 1}/{len(pending)} scored, {rate:.1f}s/track, "
+        f"~{rate * (len(pending) - i - 1) / 60:.0f} min left"
+      )
+  scores_file.close()
+
+  # -- aggregate: z-lift per (cluster, label) --------------------------------
+  labels = [label for label, _ in VOCAB]
+  matrix = np.array([done[r[1]] for r in rows if r[1] in done], dtype=np.float64)
+  clusters = np.array([int(r[0]) for r in rows if r[1] in done])
+  g_mean = matrix.mean(axis=0)
+  g_std = matrix.std(axis=0) + 1e-9
+
+  with open(NAMES_CSV, "w", newline="") as f:
+    out = csv.writer(f)
+    out.writerow(["cluster", "n_scored", "top_by_lift", "top_raw", "medoid_titles"])
+    for c in sorted(set(clusters.tolist())):
+      rows_c = matrix[clusters == c]
+      z = (rows_c.mean(axis=0) - g_mean) / g_std
+      lift_order = np.argsort(-z)[:5]
+      raw_order = np.argsort(-rows_c.mean(axis=0))[:3]
+      titles = [r[3] for r in rows if int(r[0]) == c and r[2] == "medoid"][:3]
+      lift_s = "; ".join(f"{labels[j]} ({z[j]:+.2f})" for j in lift_order)
+      raw_s = "; ".join(labels[j] for j in raw_order)
+      out.writerow([c, len(rows_c), lift_s, raw_s, " / ".join(titles)])
+      print(f"cluster {c:2d} (n={len(rows_c):2d}): {lift_s}")
+      print(f"            raw: {raw_s}")
+      print(f"            e.g. {' / '.join(titles)}")
+
+  print(f"\nWrote {NAMES_CSV}")
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/Postprocessor/ClusterNaming/sample_cluster_tracks.sql
+++ b/Postprocessor/ClusterNaming/sample_cluster_tracks.sql
@@ -1,0 +1,34 @@
+-- Exports the tracks name_clusters_muq.py listens to: per map cluster, the 10
+-- medoids (closest to the pgvector centroid of the cluster's pooled MERT
+-- embeddings) plus 6 uniform-random members as a spread check.
+--
+--   psql "$CONN" -f sample_cluster_tracks.sql > cluster_sample.csv   -- or COPY
+--
+-- Columns: cluster, track_id, role, title, media_key
+
+COPY (
+WITH cm AS (
+  SELECT m.cluster, avg(e.embedding_mean) AS centroid
+  FROM track_map m JOIN track_embedding e ON e.track_id = m.track_id
+  GROUP BY m.cluster
+),
+medoids AS (
+  SELECT m.cluster, m.track_id, t.media_key, t.name->>'default' AS title,
+         row_number() OVER (PARTITION BY m.cluster ORDER BY e.embedding_mean <=> cm.centroid) AS rn
+  FROM track_map m
+  JOIN track_embedding e ON e.track_id = m.track_id
+  JOIN cm ON cm.cluster = m.cluster
+  JOIN track t ON t.id = m.track_id
+  WHERE t.media_key IS NOT NULL
+),
+randoms AS (
+  SELECT m.cluster, m.track_id, t.media_key, t.name->>'default' AS title,
+         row_number() OVER (PARTITION BY m.cluster ORDER BY random()) AS rn
+  FROM track_map m
+  JOIN track t ON t.id = m.track_id
+  WHERE t.media_key IS NOT NULL
+)
+SELECT cluster, track_id, 'medoid', title, media_key FROM medoids WHERE rn <= 10
+UNION ALL
+SELECT cluster, track_id, 'random', title, media_key FROM randoms WHERE rn <= 6
+) TO STDOUT WITH CSV

--- a/Postprocessor/DbCommit/apply_track_map.sql
+++ b/Postprocessor/DbCommit/apply_track_map.sql
@@ -1,0 +1,50 @@
+-- Applies generate_track_map.py output. Run from the directory holding the
+-- CSV: psql "$CONN" -f apply_track_map.sql
+--
+-- The track_map table itself is backend-owned (EF migration AddTrackMap);
+-- this script only loads it. Wipe-and-reload like similar_track: coordinates
+-- and cluster labels from different layout runs are meaningless side by side,
+-- so partial loads are never allowed.
+--
+-- year and work_id are denormalized here at load time (release date through
+-- disc, and the first original work the track arranges) so the serving
+-- endpoint is a single-table scan. Tracks without playable media are skipped:
+-- every point on the map must produce sound when clicked.
+
+BEGIN;
+
+CREATE TEMP TABLE tmp_track_map (
+    track_id uuid,
+    x        real,
+    y        real,
+    cluster  smallint
+) ON COMMIT DROP;
+
+\copy tmp_track_map FROM 'track_map.csv' WITH CSV
+
+TRUNCATE track_map;
+
+INSERT INTO track_map (track_id, x, y, cluster, year, work_id)
+SELECT m.track_id,
+       m.x,
+       m.y,
+       m.cluster,
+       extract(year FROM r.release_date)::smallint,
+       ow.original_work_id
+FROM tmp_track_map m
+JOIN track t ON t.id = m.track_id
+JOIN disc d ON d.id = t.disc_id
+JOIN release r ON r.id = d.release_id
+LEFT JOIN LATERAL (
+    SELECT os.original_work_id
+    FROM track_original_song tos
+    JOIN original_song os ON os.id = tos.original_song_id
+    WHERE tos.track_id = m.track_id
+    ORDER BY os.original_work_id
+    LIMIT 1
+) ow ON true
+WHERE cardinality(t.hls_bitrates) > 0 OR t.has_dash;
+
+COMMIT;
+
+ANALYZE track_map;

--- a/Postprocessor/DbCommit/apply_track_map.sql
+++ b/Postprocessor/DbCommit/apply_track_map.sql
@@ -6,10 +6,11 @@
 -- and cluster labels from different layout runs are meaningless side by side,
 -- so partial loads are never allowed.
 --
--- year and work_id are denormalized here at load time (release date through
--- disc, and the first original work the track arranges) so the serving
--- endpoint is a single-table scan. Tracks without playable media are skipped:
--- every point on the map must produce sound when clicked.
+-- year, work_id and circle_id are denormalized here at load time (release
+-- date through disc, the first original work the track arranges, and the
+-- release's primary circle) so the serving endpoint is a single-table scan.
+-- Tracks without playable media are skipped: every point on the map must
+-- produce sound when clicked.
 
 BEGIN;
 
@@ -24,13 +25,14 @@ CREATE TEMP TABLE tmp_track_map (
 
 TRUNCATE track_map;
 
-INSERT INTO track_map (track_id, x, y, cluster, year, work_id)
+INSERT INTO track_map (track_id, x, y, cluster, year, work_id, circle_id)
 SELECT m.track_id,
        m.x,
        m.y,
        m.cluster,
        extract(year FROM r.release_date)::smallint,
-       ow.original_work_id
+       ow.original_work_id,
+       pc.circle_id
 FROM tmp_track_map m
 JOIN track t ON t.id = m.track_id
 JOIN disc d ON d.id = t.disc_id
@@ -43,6 +45,13 @@ LEFT JOIN LATERAL (
     ORDER BY os.original_work_id
     LIMIT 1
 ) ow ON true
+LEFT JOIN LATERAL (
+    SELECT rc.circle_id
+    FROM release_circle rc
+    WHERE rc.release_id = r.id
+    ORDER BY rc.ordinal
+    LIMIT 1
+) pc ON true
 WHERE cardinality(t.hls_bitrates) > 0 OR t.has_dash;
 
 COMMIT;

--- a/Postprocessor/DbCommit/generate_track_map.py
+++ b/Postprocessor/DbCommit/generate_track_map.py
@@ -1,0 +1,109 @@
+"""Projects the pooled MERT embeddings onto a 2D map for the explore point cloud.
+
+The backend stores one pooled vector per track (track_embedding.embedding_mean,
+vector(1024), provenance in embedding_config). This stage flattens that space
+into screen coordinates once, offline, so the frontend can draw the whole
+library as a WebGL scatterplot without ever touching the 1024-dim vectors:
+
+  l2-normalize -> PCA(100) -> UMAP(2d, cosine) + k-means cluster labels
+
+Clusters come from k-means over the PCA features, not density over the layout:
+the layout is one connected continent (HDBSCAN finds either ~3 regions or
+shatters into noise), while k-means always yields k acoustic families that
+project onto the map as contiguous colored regions. Labels are relabeled by
+descending cluster size. They exist to color the map into nameable regions,
+not to be authoritative genres.
+
+Reads track_embeddings.csv, exported from the DB first:
+
+  COPY (
+    SELECT track_id, embedding_mean::text FROM track_embedding
+  ) TO STDOUT WITH CSV
+
+Produces track_map.csv (track_id, x, y, cluster) with x/y scaled to [-0.95,
+0.95] preserving aspect ratio — regl-scatterplot's normalized device space —
+applied by apply_track_map.sql into the backend-owned track_map table.
+
+Run with the heavy deps injected (umap-learn brings scikit-learn):
+
+  uv run --with umap-learn python generate_track_map.py
+"""
+
+import csv
+import sys
+import time
+
+import numpy as np
+
+INPUT_CSV = "track_embeddings.csv"
+OUTPUT_CSV = "track_map.csv"
+
+PCA_DIMS = 100
+UMAP_NEIGHBORS = 50
+UMAP_MIN_DIST = 0.1
+# Enough families that each is one kind of sound, few enough that a categorical
+# palette and a future naming pass stay tractable.
+KMEANS_CLUSTERS = 48
+
+
+def load_embeddings():
+  ids, rows = [], []
+  with open(INPUT_CSV, newline="") as f:
+    for track_id, vec_text in csv.reader(f):
+      ids.append(track_id)
+      rows.append(np.fromstring(vec_text[1:-1], dtype=np.float32, sep=","))
+  return ids, np.vstack(rows)
+
+
+def main():
+  t0 = time.time()
+  print("Loading embeddings...")
+  ids, embeddings = load_embeddings()
+  print(f"  {len(ids)} tracks, dim {embeddings.shape[1]}, {time.time() - t0:.0f}s")
+
+  from sklearn.cluster import KMeans
+  from sklearn.decomposition import PCA
+  from umap import UMAP
+
+  norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+  embeddings /= np.maximum(norms, 1e-12)
+
+  print(f"PCA -> {PCA_DIMS} dims...")
+  reduced = PCA(n_components=PCA_DIMS, svd_solver="randomized").fit_transform(
+    embeddings
+  )
+  del embeddings
+
+  # No random_state on purpose: setting one forces single-threaded layout.
+  print("UMAP -> 2d (this is the long part)...")
+  coords = UMAP(
+    n_components=2,
+    n_neighbors=UMAP_NEIGHBORS,
+    min_dist=UMAP_MIN_DIST,
+    metric="cosine",
+    verbose=True,
+  ).fit_transform(reduced)
+  print(f"  done at {time.time() - t0:.0f}s")
+
+  print(f"k-means ({KMEANS_CLUSTERS}) over the PCA features...")
+  raw_labels = KMeans(n_clusters=KMEANS_CLUSTERS, n_init=4).fit_predict(reduced)
+  by_size = np.argsort(-np.bincount(raw_labels, minlength=KMEANS_CLUSTERS))
+  relabel = np.empty(KMEANS_CLUSTERS, dtype=np.int64)
+  relabel[by_size] = np.arange(KMEANS_CLUSTERS)
+  labels = relabel[raw_labels]
+  sizes = np.bincount(labels)
+  print(f"  sizes: largest {sizes[0]}, smallest {sizes[-1]}")
+
+  # Center, then scale both axes by the same factor: aspect ratio is signal.
+  coords -= (coords.min(axis=0) + coords.max(axis=0)) / 2
+  coords *= 0.95 / np.abs(coords).max()
+
+  with open(OUTPUT_CSV, "w", newline="") as f:
+    writer = csv.writer(f)
+    for track_id, (x, y), label in zip(ids, coords, labels):
+      writer.writerow([track_id, f"{x:.5f}", f"{y:.5f}", int(label)])
+  print(f"Wrote {OUTPUT_CSV} ({len(ids)} rows) in {time.time() - t0:.0f}s total")
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/Postprocessor/DbCommit/generate_track_map.py
+++ b/Postprocessor/DbCommit/generate_track_map.py
@@ -14,6 +14,15 @@ project onto the map as contiguous colored regions. Labels are relabeled by
 descending cluster size. They exist to color the map into nameable regions,
 not to be authoritative genres.
 
+Supervised mode: if existing_labels.csv (track_id,cluster — export it from the
+live track_map) sits next to the input, k-means is SKIPPED and those labels
+both ride through to the output and semi-supervise the UMAP layout
+(target_weight below), pulling each family into contiguous territory instead
+of letting 2D folding interleave them. Reuse-not-recompute matters: k-means is
+nondeterministic, so recomputing would renumber the families and silently
+misassign the curated names in track_map_cluster. Tracks absent from the
+labels file get -1, which UMAP treats as unlabeled.
+
 Reads track_embeddings.csv, exported from the DB first:
 
   COPY (
@@ -30,12 +39,14 @@ Run with the heavy deps injected (umap-learn brings scikit-learn):
 """
 
 import csv
+import os
 import sys
 import time
 
 import numpy as np
 
 INPUT_CSV = "track_embeddings.csv"
+LABELS_CSV = "existing_labels.csv"
 OUTPUT_CSV = "track_map.csv"
 
 PCA_DIMS = 100
@@ -44,6 +55,10 @@ UMAP_MIN_DIST = 0.1
 # Enough families that each is one kind of sound, few enough that a categorical
 # palette and a future naming pass stay tractable.
 KMEANS_CLUSTERS = 48
+# How hard supervised mode pulls same-family points together. 0 reproduces the
+# unsupervised layout; 1 shatters it into 48 disjoint islands and destroys the
+# between-family geography.
+TARGET_WEIGHT = 0.4
 
 
 def load_embeddings():
@@ -65,6 +80,13 @@ def main():
   from sklearn.decomposition import PCA
   from umap import UMAP
 
+  existing = None
+  if os.path.exists(LABELS_CSV):
+    by_id = {tid: int(c) for tid, c in csv.reader(open(LABELS_CSV))}
+    existing = np.array([by_id.get(t, -1) for t in ids], dtype=np.int64)
+    known = int((existing >= 0).sum())
+    print(f"supervised: {known} existing labels (k-means skipped, names stay valid)")
+
   norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
   embeddings /= np.maximum(norms, 1e-12)
 
@@ -76,23 +98,32 @@ def main():
 
   # No random_state on purpose: setting one forces single-threaded layout.
   print("UMAP -> 2d (this is the long part)...")
-  coords = UMAP(
+  reducer = UMAP(
     n_components=2,
     n_neighbors=UMAP_NEIGHBORS,
     min_dist=UMAP_MIN_DIST,
     metric="cosine",
+    target_metric="categorical",
+    target_weight=TARGET_WEIGHT,
     verbose=True,
-  ).fit_transform(reduced)
+  )
+  if existing is not None:
+    coords = reducer.fit_transform(reduced, y=existing)
+  else:
+    coords = reducer.fit_transform(reduced)
   print(f"  done at {time.time() - t0:.0f}s")
 
-  print(f"k-means ({KMEANS_CLUSTERS}) over the PCA features...")
-  raw_labels = KMeans(n_clusters=KMEANS_CLUSTERS, n_init=4).fit_predict(reduced)
-  by_size = np.argsort(-np.bincount(raw_labels, minlength=KMEANS_CLUSTERS))
-  relabel = np.empty(KMEANS_CLUSTERS, dtype=np.int64)
-  relabel[by_size] = np.arange(KMEANS_CLUSTERS)
-  labels = relabel[raw_labels]
-  sizes = np.bincount(labels)
-  print(f"  sizes: largest {sizes[0]}, smallest {sizes[-1]}")
+  if existing is not None:
+    labels = existing
+  else:
+    print(f"k-means ({KMEANS_CLUSTERS}) over the PCA features...")
+    raw_labels = KMeans(n_clusters=KMEANS_CLUSTERS, n_init=4).fit_predict(reduced)
+    by_size = np.argsort(-np.bincount(raw_labels, minlength=KMEANS_CLUSTERS))
+    relabel = np.empty(KMEANS_CLUSTERS, dtype=np.int64)
+    relabel[by_size] = np.arange(KMEANS_CLUSTERS)
+    labels = relabel[raw_labels]
+    sizes = np.bincount(labels)
+    print(f"  sizes: largest {sizes[0]}, smallest {sizes[-1]}")
 
   # A handful of stray points otherwise dictate the frame and shove the dense
   # continent off-center: clamp to the 0.1..99.9 percentile box first (strays

--- a/Postprocessor/DbCommit/generate_track_map.py
+++ b/Postprocessor/DbCommit/generate_track_map.py
@@ -94,7 +94,12 @@ def main():
   sizes = np.bincount(labels)
   print(f"  sizes: largest {sizes[0]}, smallest {sizes[-1]}")
 
-  # Center, then scale both axes by the same factor: aspect ratio is signal.
+  # A handful of stray points otherwise dictate the frame and shove the dense
+  # continent off-center: clamp to the 0.1..99.9 percentile box first (strays
+  # pin to the edge instead of stretching it). Then center and scale both axes
+  # by the same factor: aspect ratio is signal.
+  lo, hi = np.percentile(coords, [0.1, 99.9], axis=0)
+  coords = np.clip(coords, lo, hi)
   coords -= (coords.min(axis=0) + coords.max(axis=0)) / 2
   coords *= 0.95 / np.abs(coords).max()
 


### PR DESCRIPTION
Adds the point-cloud layout stage behind the frontend's new /explore/map:

- `generate_track_map.py`: pooled MERT vectors → l2-normalize → PCA(100) → UMAP 2D (cosine) + k-means(48) acoustic families, outliers clamped to the 0.1–99.9 percentile box, coords normalized to regl-scatterplot's [-1, 1] space.
- `apply_track_map.sql`: wipe-and-reload into the backend-owned `track_map` table (EF migration AddTrackMap), denormalizing year and first-arranged-work at load time; media-less tracks skipped so every point is playable.

Ran against the cluster 2026-07-30: 164,222 embeddings in, 163,431 points loaded (48 clusters, largest 5,770 / smallest 326).

🤖 Generated with [Claude Code](https://claude.com/claude-code)